### PR TITLE
List the provided modules in META.yml

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,3 +7,4 @@ copyright_holder = Yuval Kogman
 [@NUFFIN]
 dist = Data-Thunk
 repository_at = github
+[MetaProvides::Package]


### PR DESCRIPTION
Dist::Zilla::Plugin::MetaProvides does this automatically.
